### PR TITLE
Adds MII CDS Dokument search params: creation, doc-status, nlp-processing-status

### DIFF
--- a/fsh-generated/resources/SearchParameter-mii-sp-meta-dokument-documentreference-attachment-creation.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-meta-dokument-documentreference-attachment-creation.json
@@ -1,0 +1,47 @@
+{
+  "resourceType": "SearchParameter",
+  "id": "mii-sp-meta-dokument-documentreference-attachment-creation",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/modul-meta/StructureDefinition/mii-pr-meta-searchparameter"
+    ]
+  },
+  "url": "https://www.medizininformatik-initiative.de/fhir/modul-meta/SearchParameter/mii-sp-meta-dokument-documentreference-attachment-creation",
+  "publisher": "Medizininformatik Initiative",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "https://www.medizininformatik-initiative.de"
+        }
+      ]
+    }
+  ],
+  "version": "2025.0.0",
+  "extension": [
+    {
+      "url": "https://www.medizininformatik-initiative.de/fhir/modul-meta/StructureDefinition/mii-ex-meta-license-codeable",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "code": "CC-BY-4.0",
+            "system": "http://hl7.org/fhir/spdx-license",
+            "display": "Creative Commons Attribution 4.0 International"
+          }
+        ]
+      }
+    }
+  ],
+  "name": "MII_SP_Meta_DocumentReference_Attachment_Creation",
+  "status": "active",
+  "description": "Suchparameter für DocumentReference.content.attachment.creation",
+  "experimental": false,
+  "date": "2025-06-23",
+  "code": "creation",
+  "base": [
+    "DocumentReference"
+  ],
+  "type": "date",
+  "expression": "DocumentReference.content.attachment.creation"
+}

--- a/fsh-generated/resources/SearchParameter-mii-sp-meta-dokument-documentreference-doc-status.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-meta-dokument-documentreference-doc-status.json
@@ -1,0 +1,47 @@
+{
+  "resourceType": "SearchParameter",
+  "id": "mii-sp-meta-dokument-documentreference-doc-status",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/modul-meta/StructureDefinition/mii-pr-meta-searchparameter"
+    ]
+  },
+  "url": "https://www.medizininformatik-initiative.de/fhir/modul-meta/SearchParameter/mii-sp-meta-dokument-documentreference-doc-status",
+  "publisher": "Medizininformatik Initiative",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "https://www.medizininformatik-initiative.de"
+        }
+      ]
+    }
+  ],
+  "version": "2025.0.0",
+  "extension": [
+    {
+      "url": "https://www.medizininformatik-initiative.de/fhir/modul-meta/StructureDefinition/mii-ex-meta-license-codeable",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "code": "CC-BY-4.0",
+            "system": "http://hl7.org/fhir/spdx-license",
+            "display": "Creative Commons Attribution 4.0 International"
+          }
+        ]
+      }
+    }
+  ],
+  "name": "MII_SP_Meta_DocumentReference_Document_Status",
+  "status": "active",
+  "description": "Suchparameter für DocumentReference.docStatus",
+  "experimental": false,
+  "date": "2025-06-23",
+  "code": "doc-status",
+  "base": [
+    "DocumentReference"
+  ],
+  "type": "token",
+  "expression": "DocumentReference.docStatus"
+}

--- a/fsh-generated/resources/SearchParameter-mii-sp-meta-dokument-documentreference-nlp-processing-status.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-meta-dokument-documentreference-nlp-processing-status.json
@@ -1,0 +1,47 @@
+{
+  "resourceType": "SearchParameter",
+  "id": "mii-sp-meta-dokument-documentreference-nlp-processing-status",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/modul-meta/StructureDefinition/mii-pr-meta-searchparameter"
+    ]
+  },
+  "url": "https://www.medizininformatik-initiative.de/fhir/modul-meta/SearchParameter/mii-sp-meta-dokument-documentreference-nlp-processing-status",
+  "publisher": "Medizininformatik Initiative",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "https://www.medizininformatik-initiative.de"
+        }
+      ]
+    }
+  ],
+  "version": "2025.0.0",
+  "extension": [
+    {
+      "url": "https://www.medizininformatik-initiative.de/fhir/modul-meta/StructureDefinition/mii-ex-meta-license-codeable",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "code": "CC-BY-4.0",
+            "system": "http://hl7.org/fhir/spdx-license",
+            "display": "Creative Commons Attribution 4.0 International"
+          }
+        ]
+      }
+    }
+  ],
+  "name": "MII_SP_Meta_DocumentReference_NLP_Processing_Status",
+  "status": "active",
+  "description": "Suchparameter für DocumentReference.extension[nlp-processing-status].valueCodeableConcept",
+  "experimental": false,
+  "date": "2025-06-23",
+  "code": "nlp-processing-status",
+  "base": [
+    "DocumentReference"
+  ],
+  "type": "token",
+  "expression": "DocumentReference.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-dokument/StructureDefinition/mii-ex-dokument-nlp-processing-status').valueCodeableConcept"
+}

--- a/fsh-generated/resources/SearchParameter-mii-sp-meta-dokument-documentreference-nlp-processing-status.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-meta-dokument-documentreference-nlp-processing-status.json
@@ -37,11 +37,11 @@
   "status": "active",
   "description": "Suchparameter für DocumentReference.extension[nlp-processing-status].valueCodeableConcept",
   "experimental": false,
-  "date": "2025-06-23",
+  "date": "2025-07-30",
   "code": "nlp-processing-status",
   "base": [
     "DocumentReference"
   ],
   "type": "token",
-  "expression": "DocumentReference.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-dokument/StructureDefinition/mii-ex-dokument-nlp-processing-status').valueCodeableConcept"
+  "expression": "DocumentReference.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-dokument/StructureDefinition/mii-ex-dokument-nlp-processing-status').value"
 }

--- a/input/fsh/searchparameters/mii-sp-meta-dokument.fsh
+++ b/input/fsh/searchparameters/mii-sp-meta-dokument.fsh
@@ -46,8 +46,8 @@ Usage: #definition
 * status = #active
 * description = "Suchparameter für DocumentReference.extension[nlp-processing-status].valueCodeableConcept"
 * experimental = false
-* date = "2025-06-23"
+* date = "2025-07-30"
 * code = #nlp-processing-status
 * base = #DocumentReference
 * type = #token
-* expression = "DocumentReference.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-dokument/StructureDefinition/mii-ex-dokument-nlp-processing-status').valueCodeableConcept"
+* expression = "DocumentReference.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-dokument/StructureDefinition/mii-ex-dokument-nlp-processing-status').value"

--- a/input/fsh/searchparameters/mii-sp-meta-dokument.fsh
+++ b/input/fsh/searchparameters/mii-sp-meta-dokument.fsh
@@ -1,0 +1,53 @@
+Instance: mii-sp-meta-dokument-documentreference-attachment-creation
+InstanceOf: MII_PR_Meta_SearchParameter
+Usage: #definition
+* insert SP_Publisher
+* insert Version
+* insert LicenseCodeableCCBY40Instance
+* insert SP_Profile
+//* url = "https://www.medizininformatik-initiative.de/fhir/ext/modul-dokument/SearchParameter/DocumentReference-creation"
+* name = "MII_SP_Meta_DocumentReference_Attachment_Creation"
+* status = #active
+* description = "Suchparameter für DocumentReference.content.attachment.creation"
+* experimental = false
+* date = "2025-06-23"
+* code = #creation
+* base = #DocumentReference
+* type = #date
+* expression = "DocumentReference.content.attachment.creation"
+
+Instance: mii-sp-meta-dokument-documentreference-doc-status
+InstanceOf: MII_PR_Meta_SearchParameter
+Usage: #definition
+* insert SP_Publisher
+* insert Version
+* insert LicenseCodeableCCBY40Instance
+* insert SP_Profile
+//* url = "https://www.medizininformatik-initiative.de/fhir/ext/modul-dokument/SearchParameter/DocumentReference-doc-status"
+* name = "MII_SP_Meta_DocumentReference_Document_Status"
+* status = #active
+* description = "Suchparameter für DocumentReference.docStatus"
+* experimental = false
+* date = "2025-06-23"
+* code = #doc-status
+* base = #DocumentReference
+* type = #token
+* expression = "DocumentReference.docStatus"
+
+Instance: mii-sp-meta-dokument-documentreference-nlp-processing-status
+InstanceOf: MII_PR_Meta_SearchParameter
+Usage: #definition
+//* url = "https://www.medizininformatik-initiative.de/fhir/ext/modul-dokument/SearchParameter/DocumentReference-nlp-processing-status"
+* insert SP_Publisher
+* insert Version
+* insert LicenseCodeableCCBY40Instance
+* insert SP_Profile
+* name = "MII_SP_Meta_DocumentReference_NLP_Processing_Status"
+* status = #active
+* description = "Suchparameter für DocumentReference.extension[nlp-processing-status].valueCodeableConcept"
+* experimental = false
+* date = "2025-06-23"
+* code = #nlp-processing-status
+* base = #DocumentReference
+* type = #token
+* expression = "DocumentReference.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-dokument/StructureDefinition/mii-ex-dokument-nlp-processing-status').valueCodeableConcept"


### PR DESCRIPTION
Creates new DocumentReference search parameters for the [MII CDS Dokument module's profile](https://simplifier.net/guide/medizininformatikinitiative-dokument/MIIIGModulDokument/TechnischeImplementierung/FHIRProfile/Dokument-DocumentReference.page.md?version=current):

- `DocumentReference.content.attachment.creation`: Creation date time of the document, for which the document reference is created
- `DocumentReference.docStatus`: Lifecycle state of the document, for which the document reference is created
- `DocumentReference.extension[nlp-processing-status].valueCodeableConcept`: Status of the document, which might be created as result of NLP processing pipeline, esp. used by the GeMTeX module/ project

Note: Search parameters `creation` and `doc-status` are not default [DocumentReference R4search parameters](https://www.hl7.org/fhir/R4/documentreference.html#search) , but they will be when using [DocumentReference R5](https://hl7.org/fhir/R5/documentreference.html#search).