### PR TITLE
Update mii-cs-meta-diz-standorte.fsh

### DIFF
--- a/fsh-generated/resources/CodeSystem-mii-cs-meta-diz-standorte.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-meta-diz-standorte.json
@@ -349,7 +349,7 @@
         },
         {
           "code": "uri",
-          "valueString": "kgu.de"
+          "valueString": "unimedizin-ffm.de"
         },
         {
           "code": "status",

--- a/input/fsh/codesystems/mii-cs-meta-diz-standorte.fsh
+++ b/input/fsh/codesystems/mii-cs-meta-diz-standorte.fsh
@@ -138,7 +138,7 @@ Description: "Medizininformatik-Initiative Standorte"
 * #UME insert AddTRV(V6.15)
 * #UKF "Universitätsklinikum Frankfurt" "Frankfurt"
 * #UKF insert AddKonsortium(MIRACUM)
-* #UKF insert AddUri(kgu.de)
+* #UKF insert AddUri(unimedizin-ffm.de)
 * #UKF insert AddStatus(active)
 * #UKF insert AddTRV(V6.14)
 * #UKFR "Universitätsklinikum Freiburg" "Freiburg"


### PR DESCRIPTION
The URI of `kgu.de` has been changed to `unimedizin-ffm.de`.