### PR TITLE
fix: use GET /fhir/metadata for NGINX health check to enforce mTLS

### DIFF
--- a/.github/workflows/ci_java_validation.yml
+++ b/.github/workflows/ci_java_validation.yml
@@ -110,7 +110,7 @@ jobs:
             sleep 5  # Give NGINX some time to start
 
             for i in {1..5}; do
-            if curl --head --silent --fail http://localhost:8090; then
+            if curl --silent --fail http://localhost:8090/fhir/metadata; then
               echo "NGINX is responding."
               break
             else


### PR DESCRIPTION
fixes #204